### PR TITLE
Fix #2 and #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ sdist
 *.swp
 .idea/
 dist/
+build/

--- a/hackhttp/hackhttp.py
+++ b/hackhttp/hackhttp.py
@@ -46,6 +46,7 @@ class httpconpool():
     # 存放 cookie 的池子，key 为 host
     maxconnectpool = 20
     lock = threading.Lock()
+
     def __init__(self, maxconnectpool=20, timeout=10):
         self.maxconnectpool = maxconnectpool
         self.timeout = timeout
@@ -170,6 +171,8 @@ class hackhttp():
     def _decode_html(self, head, body):
         # 这里处理编码有问题，所以暂不处理
         # return body
+        if 'text' not in head:
+            return body
         charset = None
         r = re.search(r'charset=(\S+)', head, re.I)
         if not r:
@@ -386,6 +389,8 @@ class hackhttp():
                 # content-length err 411
                 tmpheaders[
                     'Content-Length'] = tmpheaders.get('Content-Length', 0)
+                if method == 'GET':
+                    del tmpheaders['Content-Length']
             con.request(method, path, post, tmpheaders)
             rep = con.getresponse()
             body = rep.read()


### PR DESCRIPTION
- 删除 GET 请求时,多余的头部 Content-Length(非 GET 请求时，允许 Content-Length: 0)
- 修正返回体解码规则(如果不是 `text/*` 形式的，一率不解码，返回 bytes)
